### PR TITLE
"dorp" => "drop"

### DIFF
--- a/docs/Tutorial-Setup/Governor.md
+++ b/docs/Tutorial-Setup/Governor.md
@@ -8,7 +8,7 @@ The purpose of the governor is to maintain a constant headspeed regardless of fl
 :::
 
 # Governor Features
-The governor can be turned ON/OFF with the dorp down menu within **Governor Features** from the **Motors** Tab.
+The governor can be turned ON/OFF with the drop down menu within **Governor Features** from the **Motors** Tab.
 
 ![Governor](./img/governor-features-off.png)
 


### PR DESCRIPTION
Fix a silly typo.