### PR TITLE
Update flydragon2.2.md doc with RPM-S 5v supply warning

### DIFF
--- a/docs/Controllers/flydragon2.2.md
+++ b/docs/Controllers/flydragon2.2.md
@@ -60,6 +60,8 @@ To use the Flydragon with a motorised tail the Servo 4 needs to be remapped to M
 
 ![Wiring Diagram v2.2](./img/wiring-diagram-v2.png)
 
+* WARNING: The RPM-S Port is powered via the internal 5V supply which is also powered during USB connection. If you have any power supplies connected or innapropriate loads you are likely to damage your board. DO NOT plug in your ESCs BEC wire into here, many BECs act like a deadshort if you attempt to backfeed them and you WILL blow out the 5V supply on your board when you connect USB if you do this. Power to the rest of the ports is all common power you can connect whatever to.
+
 ### UART ports
 
 * UART 1 - Internal ELRS Receiver - (disable as shown below if not used)  


### PR DESCRIPTION
- Added warning regarding the RPM-S port and it's 5V supply