### PR TITLE
fix video banner autoplay on iPhone

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -10,7 +10,14 @@ import styles from './index.module.css';
 function HomepageHeader() {
   return (
     <div className={styles.wrapper}>
-      <video src={BGV} className={styles.video} loop autoPlay muted />
+      <video
+        src={BGV}
+        className={styles.video}
+        autoPlay
+        playsInline
+        loop
+        muted
+      />
       <div className={styles.mask}></div>
       <Rotorflightsvg className={styles.content} />
     </div>


### PR DESCRIPTION
The `playsinline` attribute is required to autoplay videos on the iPhone.

See https://webkit.org/blog/6784/new-video-policies-for-ios/ for more details.